### PR TITLE
Verilog Register Updates - Do no allow writes to $0, misc cleanup

### DIFF
--- a/verilog/Register.v
+++ b/verilog/Register.v
@@ -83,18 +83,19 @@ regOut24,regOut25,regOut26,regOut27,regOut28,regOut29,regOut30,regOut31
 	integer i, j;
 	
 	initial begin 
-		for(j = 0; j < 32; j = j + 1) begin
-				registers[j] <= 0;
+		for(i = 0; i < 32; i = i + 1) begin
+				registers[i] <= 0;
 		end
 	end
 	
 	always begin
 		@(posedge Clk) begin
-			if (RegWr)
+			if (RegWr) begin
 				registers[RW] <= BusW;
+			end
 			else if (Rst) begin
-				for(i = 0; i < 32; i = i + 1) 
-					registers[i] <= 0;
+				for(j = 0; j < 32; j = j + 1) 
+					registers[j] <= 0;
 			end
 		end
 		

--- a/verilog/Register.v
+++ b/verilog/Register.v
@@ -82,7 +82,7 @@ regOut24,regOut25,regOut26,regOut27,regOut28,regOut29,regOut30,regOut31
 	
 	integer i, j;
 	
-	initial begin 
+	initial begin //initialize all register values to 0
 		for(i = 0; i < 32; i = i + 1) begin
 				registers[i] <= 0;
 		end
@@ -90,7 +90,7 @@ regOut24,regOut25,regOut26,regOut27,regOut28,regOut29,regOut30,regOut31
 	
 	always begin
 		@(posedge Clk) begin
-			if (RegWr) begin
+			if (RegWr && RW != 0) begin //$0 must remain unchanged as 0
 				registers[RW] <= BusW;
 			end
 			else if (Rst) begin


### PR DESCRIPTION
The $zero register was being written over with other values and should always remain set to 0.  Now it cannot be overwritten and will always return 0.   Also did some other minor cleanup.