### PR TITLE
Added Multiplexor Test Benches and Minor bug fixes to Multiplexor.v 

### DIFF
--- a/verilog/Multiplexers.v
+++ b/verilog/Multiplexers.v
@@ -11,9 +11,9 @@
 //if 0, selected input is 1st register file's output: rs 
 //if 1, selected input is forwarded ex to ex
 //if 2, selected input is forwarded mem to ex
-module first_alu_mux_3_to_1(In1_RegRs, In2_fwdEx, In3_fwdMem, Ctrl_FwdA, out)
+module first_alu_mux_3_to_1(In1_RegRs, In2_fwdEx, In3_fwdMem, Ctrl_FwdA, out);
 	input [31:0] In1_RegRs, In2_fwdEx, In3_fwdMem;
-	input Ctrl_FwdA;
+	input [1:0] Ctrl_FwdA;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_RegRs, In2_fwdEx, In3_fwdMem, Ctrl_FwdA) begin
 		case (Ctrl_FwdA) 
@@ -29,7 +29,7 @@ endmodule
 //if 0, selected input is 2nd register output rt 
 //if 1, selected input is forwarded ex to ex
 //if 2, selected input is forwarded mem to ex
-module second_alu_mux_3_to_1(In1_RegRt, In2_fwdEx, In3_fwdMem, Ctrl_FwdB, out)
+module second_alu_mux_3_to_1(In1_RegRt, In2_fwdEx, In3_fwdMem, Ctrl_FwdB, out);
 	input [31:0] In1_RegRt, In2_fwdEx, In3_fwdMem;
 	input [1:0] Ctrl_FwdB;
 	output reg [31:0] out; // 32-bit output
@@ -47,7 +47,7 @@ endmodule
 // if 0, take input from 2nd mux (can be either 2nd register rt, forwarded value mem to ex, 
 // or forwarded value ex to ex
 // if 1, take input from 16bit immediate after it's sign extended
-module third_alu_mux_2_to_1(In1_second_alu_mux, In2_immediate, Ctrl_ALUSrc, out)
+module third_alu_mux_2_to_1(In1_second_alu_mux, In2_immediate, Ctrl_ALUSrc, out);
 	input [31:0] In1_second_alu_mux, In2_immediate;
 	input Ctrl_ALUSrc;
 	output reg [31:0] out; // 32-bit output
@@ -64,14 +64,14 @@ endmodule
 //Inputs: rd, rt; Outputs: the chosen destination register
 //if 0: rt (immediate type)
 //if 1: rd (R type)
-module idEx_to_exMem_mux_2_to_1(In1_rd, In2_rt, Ctrl_RegDst, out)
+module idEx_to_exMem_mux_2_to_1(In1_rd, In2_rt, Ctrl_RegDst, out);
 	input [31:0] In1_rd, In2_rt;
 	input [1:0] Ctrl_RegDst;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_rd, In2_rt, Ctrl_RegDst) begin
 		case (Ctrl_RegDst) 
-			0: out <= In1_rt;
-			1: out <= In2_rd;
+			0: out <= In1_rd;
+			1: out <= In2_rt;
 		endcase
 	end
 endmodule
@@ -82,7 +82,7 @@ endmodule
 //if 0, R type and take ALU result
 //if 1, lw and take mem stage output
 //if 2, jal and take hardcoded PC+4 because we need to save in $ra for returning
-module writeback_source_mux_3_to_1(In1_ALU_Result, In2_Mem_output, In3_PC_plus_4, Ctrl_MemToReg, out)
+module writeback_source_mux_3_to_1(In1_ALU_Result, In2_Mem_output, In3_PC_plus_4, Ctrl_MemToReg, out);
 	input [31:0] In1_ALU_Result, In2_Mem_output, In3_PC_plus_4;
 	input [1:0] Ctrl_MemToReg;
 	output reg [31:0] out; // 32-bit output
@@ -103,7 +103,7 @@ endmodule
 // if 0, if some immediate type (e.g., lw) address comes from 2nd read register, bits 20:16
 // if 1, R type, address comes from rd bits 15:11
 // if 2, jal and address is hardcoded $31 for $ra slot
-module regDst_mux_3_to_1(In1_imm_destination_rt, In2_rType_rd, In3_jal_ra, Ctrl_RegDst, out)
+module regDst_mux_3_to_1(In1_imm_destination_rt, In2_rType_rd, In3_jal_ra, Ctrl_RegDst, out);
 	input [31:0] In1_imm_destination_rt, In2_rType_rd, In3_jal_ra;
 	input [1:0] Ctrl_RegDst;
 	output reg [31:0] out; // 32-bit output
@@ -125,7 +125,7 @@ endmodule
 // Control line comes from branch decision AND gate
 // if control is 0, select PC+4
 // if control is 1, select sign extended label added to PC for BTA
-module first_jump_or_branch_mux_2_to_1(In1_PC_plus_4, In2_BTA, Ctrl_Branch_Gate, out)
+module first_jump_or_branch_mux_2_to_1(In1_PC_plus_4, In2_BTA, Ctrl_Branch_Gate, out);
 	input [31:0] In1_PC_plus_4, In2_BTA;
 	input [1:0] Ctrl_Branch_Gate;
 	output reg [31:0] out; // 32-bit output
@@ -144,7 +144,7 @@ endmodule
 // Control line comes from Control Unit jump line. If 1, then it's a jump. Take 2nd input.
 // If 0, it is the 1st input (can be either PC+4 or BTA depending on 1st mux result)
 // If 1, calculated jump address (shift two, concat top 4 of PC)
-module second_jump_or_branch_mux_2_to_1(In1_first_mux, In2_jump_addr_calc, Ctrl_Jump, out)
+module second_jump_or_branch_mux_2_to_1(In1_first_mux, In2_jump_addr_calc, Ctrl_Jump, out);
 	input [31:0] In1_first_mux, In2_jump_addr_calc;
 	input Ctrl_Jump;
 	output reg [31:0] out; // 32-bit output
@@ -162,7 +162,7 @@ endmodule
 //Control line comes from the JRControl module in ALU Control
 //If control is 0 we take 1st input as determined by 2nd mux
 //If control is 1 we take register value which contains jr address
-module third_jump_or_branch_mux_2_to_1(In1_second_mux, In2_reg_value_ra, JRCtrl, out)
+module third_jump_or_branch_mux_2_to_1(In1_second_mux, In2_reg_value_ra, JRCtrl, out);
 	input [31:0] In1_second_mux, In2_reg_value_ra;
 	input [1:0] JRCtrl;
 	output reg [31:0] out; // 32-bit output
@@ -181,7 +181,7 @@ endmodule
 //Inputs: Control Unit signal, hardcoded zero 
 //If Control is 0, output is whatever is sent by Control Unit
 //If Control is 1, output is 0 and sent to ID/EX wb, m, and ex control lines
-module hazard_stall_mux_2_to_1(In1_zero, In2_control_unit, Ctrl_Mux_Select_Stall, out)
+module hazard_stall_mux_2_to_1(In1_zero, In2_control_unit, Ctrl_Mux_Select_Stall, out);
 	input [31:0] In1_zero, In2_control_unit;
 	input [1:0] Ctrl_Mux_Select_Stall;
 	output reg [31:0] out; // 32-bit output

--- a/verilog/Multiplexers.v
+++ b/verilog/Multiplexers.v
@@ -66,7 +66,7 @@ endmodule
 //if 1: rd (R type)
 module idEx_to_exMem_mux_2_to_1(In1_rd, In2_rt, Ctrl_RegDst, out);
 	input [31:0] In1_rd, In2_rt;
-	input Ctrl_RegDst;
+	input [1:0] Ctrl_RegDst;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_rd, In2_rt, Ctrl_RegDst) begin
 		case (Ctrl_RegDst) 

--- a/verilog/Multiplexers.v
+++ b/verilog/Multiplexers.v
@@ -66,7 +66,7 @@ endmodule
 //if 1: rd (R type)
 module idEx_to_exMem_mux_2_to_1(In1_rd, In2_rt, Ctrl_RegDst, out);
 	input [31:0] In1_rd, In2_rt;
-	input [1:0] Ctrl_RegDst;
+	input Ctrl_RegDst;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_rd, In2_rt, Ctrl_RegDst) begin
 		case (Ctrl_RegDst) 
@@ -127,7 +127,7 @@ endmodule
 // if control is 1, select sign extended label added to PC for BTA
 module first_jump_or_branch_mux_2_to_1(In1_PC_plus_4, In2_BTA, Ctrl_Branch_Gate, out);
 	input [31:0] In1_PC_plus_4, In2_BTA;
-	input [1:0] Ctrl_Branch_Gate;
+	input Ctrl_Branch_Gate;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_PC_plus_4, In2_BTA, Ctrl_Branch_Gate) begin
 		case (Ctrl_Branch_Gate) 
@@ -164,7 +164,7 @@ endmodule
 //If control is 1 we take register value which contains jr address
 module third_jump_or_branch_mux_2_to_1(In1_second_mux, In2_reg_value_ra, JRCtrl, out);
 	input [31:0] In1_second_mux, In2_reg_value_ra;
-	input [1:0] JRCtrl;
+	input JRCtrl;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_second_mux, In2_reg_value_ra, JRCtrl) begin
 		case (JRCtrl) 
@@ -183,7 +183,7 @@ endmodule
 //If Control is 1, output is 0 and sent to ID/EX wb, m, and ex control lines
 module hazard_stall_mux_2_to_1(In1_zero, In2_control_unit, Ctrl_Mux_Select_Stall, out);
 	input [31:0] In1_zero, In2_control_unit;
-	input [1:0] Ctrl_Mux_Select_Stall;
+	input Ctrl_Mux_Select_Stall;
 	output reg [31:0] out; // 32-bit output
 	always @(In1_zero, In2_control_unit, Ctrl_Mux_Select_Stall) begin
 		case (Ctrl_Mux_Select_Stall) 

--- a/verilog/Multiplexers_tb.v
+++ b/verilog/Multiplexers_tb.v
@@ -1,0 +1,171 @@
+`timescale 1 ns / 1 ns
+
+//1st ALU source rs TB
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, 2, and then 0.
+
+module first_alu_mux_3_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_RegRs, In2_fwdEx, In3_fwdMem;
+reg [1:0] Ctrl_FwdA;
+wire [31:0] out;
+
+first_alu_mux_3_to_1 dut(	
+
+	.In1_RegRs(In1_RegRs), 
+	.In2_fwdEx(In2_fwdEx), 
+	.In3_fwdMem(In3_fwdMem), 
+	.Ctrl_FwdA(Ctrl_FwdA),
+	.out(out)
+
+			);
+
+integer seed = 1 ;
+
+initial begin
+		$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_FwdA = 0;
+		#5
+		Ctrl_FwdA = 0;
+		In1_RegRs = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		#5
+		In1_RegRs = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdA = 1;
+		#5
+		In1_RegRs = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdA = 2;
+		#5
+		In1_RegRs = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdA = 0;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//2nd ALU source rt test bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, 2, and then 0.
+
+module second_alu_mux_3_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_RegRt, In2_fwdEx, In3_fwdMem;
+reg [1:0] Ctrl_FwdB;
+wire [31:0] out;
+
+second_alu_mux_3_to_1 dut(	
+
+	.In1_RegRt(In1_RegRt), 
+	.In2_fwdEx(In2_fwdEx), 
+	.In3_fwdMem(In3_fwdMem), 
+	.Ctrl_FwdB(Ctrl_FwdB),
+	.out(out)
+
+			);
+
+integer seed = 2 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_FwdB = 0;
+		#5
+		Ctrl_FwdB = 0;
+		In1_RegRt = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		#5
+		In1_RegRt = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdB = 1;
+		#5
+		In1_RegRt = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdB = 2;
+		#5
+		In1_RegRt = $random(seed);
+		In2_fwdEx = $random(seed);
+		In3_fwdMem = $random(seed);
+		Ctrl_FwdB = 0;
+		#5
+		$finish;
+	end
+
+endmodule
+
+
+//--------------------------------------------------------------
+//3rd ALU for source
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, 2, and then 0.
+
+module third_alu_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_second_alu_mux, In2_immediate;
+reg Ctrl_ALUSrc;
+wire [31:0] out;
+
+third_alu_mux_2_to_1 dut(	
+
+	.In1_second_alu_mux(In1_second_alu_mux), 
+	.In2_immediate(In2_immediate), 
+	.Ctrl_ALUSrc(Ctrl_ALUSrc),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_ALUSrc = 0;
+		#5
+		Ctrl_ALUSrc = 0;
+		In1_second_alu_mux = $random(seed);
+		In2_immediate = $random(seed);
+		#5
+		In1_second_alu_mux = $random(seed);
+		In2_immediate = $random(seed);
+		Ctrl_ALUSrc = 1;
+		#5
+		In1_second_alu_mux = $random(seed);
+		In2_immediate = $random(seed);
+		Ctrl_ALUSrc = 0;
+		#5
+		$finish;
+	end
+
+endmodule

--- a/verilog/Multiplexers_tb.v
+++ b/verilog/Multiplexers_tb.v
@@ -185,7 +185,7 @@ parameter tck = 10; ///< clock tick
 
 //input and output regs
 reg [31:0] In1_rd, In2_rt;
-reg Ctrl_RegDst;
+reg [1:0] Ctrl_RegDst;
 wire [31:0] out;
 
 idEx_to_exMem_mux_2_to_1 dut(	

--- a/verilog/Multiplexers_tb.v
+++ b/verilog/Multiplexers_tb.v
@@ -123,7 +123,7 @@ endmodule
 //--------------------------------------------------------------
 //3rd ALU for source
 //Changes input registers randomly every 5 time units.
-//Changes FwdA_control to 0, 1, 2, and then 0.
+//Changes FwdA_control to 0, 1, and then 0.
 
 module third_alu_mux_2_to_1_tb();
 
@@ -164,6 +164,400 @@ initial begin
 		In1_second_alu_mux = $random(seed);
 		In2_immediate = $random(seed);
 		Ctrl_ALUSrc = 0;
+		#5
+		In1_second_alu_mux = $random(seed);
+		In2_immediate = $random(seed);
+		Ctrl_ALUSrc = 1;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//ID/EX to EX/MEM Multiplexor Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, and then 0.
+
+module idEx_to_exMem_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_rd, In2_rt;
+reg Ctrl_RegDst;
+wire [31:0] out;
+
+idEx_to_exMem_mux_2_to_1 dut(	
+
+	.In1_rd(In1_rd), 
+	.In2_rt(In2_rt), 
+	.Ctrl_RegDst(Ctrl_RegDst),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_RegDst = 0;
+		#5
+		Ctrl_RegDst = 0;
+		In1_rd = $random(seed);
+		In2_rt = $random(seed);
+		#5
+		In1_rd = $random(seed);
+		In2_rt = $random(seed);
+		Ctrl_RegDst = 1;
+		#5
+		In1_rd = $random(seed);
+		In2_rt = $random(seed);
+		Ctrl_RegDst = 0;
+		#5
+		In1_rd = $random(seed);
+		In2_rt = $random(seed);
+		Ctrl_RegDst = 1;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//Writeback Source MUX Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, 2, and then 0.
+
+module writeback_source_mux_3_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_ALU_Result, In2_Mem_output, In3_PC_plus_4;
+reg [1:0] Ctrl_MemToReg;
+wire [31:0] out;
+
+writeback_source_mux_3_to_1 dut(	
+
+	.In1_ALU_Result(In1_ALU_Result), 
+	.In2_Mem_output(In2_Mem_output), 
+	.In3_PC_plus_4(In3_PC_plus_4), 
+	.Ctrl_MemToReg(Ctrl_MemToReg),
+	.out(out)
+
+			);
+
+integer seed = 2 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_MemToReg = 0;
+		#5
+		Ctrl_MemToReg = 0;
+		In1_ALU_Result = $random(seed);
+		In2_Mem_output = $random(seed);
+		In3_PC_plus_4 = $random(seed);
+		#5
+		Ctrl_MemToReg = 1;
+		In1_ALU_Result = $random(seed);
+		In2_Mem_output = $random(seed);
+		In3_PC_plus_4 = $random(seed);
+		#5
+		Ctrl_MemToReg = 2;
+		In1_ALU_Result = $random(seed);
+		In2_Mem_output = $random(seed);
+		In3_PC_plus_4 = $random(seed);
+		#5
+		Ctrl_MemToReg = 0;
+		In1_ALU_Result = $random(seed);
+		In2_Mem_output = $random(seed);
+		In3_PC_plus_4 = $random(seed);
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//Write Address Determination MUX Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, 2, and then 0.
+
+module regDst_mux_3_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_imm_destination_rt, In2_rType_rd, In3_jal_ra;
+reg [1:0] Ctrl_RegDst;
+wire [31:0] out;
+
+regDst_mux_3_to_1 dut(	
+
+	.In1_imm_destination_rt(In1_imm_destination_rt), 
+	.In2_rType_rd(In2_rType_rd), 
+	.In3_jal_ra(In3_jal_ra), 
+	.Ctrl_RegDst(Ctrl_RegDst),
+	.out(out)
+
+			);
+
+integer seed = 2 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_RegDst = 0;
+		#5
+		Ctrl_RegDst = 0;
+		In1_imm_destination_rt = $random(seed);
+		In2_rType_rd = $random(seed);
+		In3_jal_ra = $random(seed);
+		#5
+		Ctrl_RegDst = 1;
+		In1_imm_destination_rt = $random(seed);
+		In2_rType_rd = $random(seed);
+		In3_jal_ra = $random(seed);
+		#5
+		Ctrl_RegDst = 2;
+		In1_imm_destination_rt = $random(seed);
+		In2_rType_rd = $random(seed);
+		In3_jal_ra = $random(seed);
+		#5
+		Ctrl_RegDst = 0;
+		In1_imm_destination_rt = $random(seed);
+		In2_rType_rd = $random(seed);
+		In3_jal_ra = $random(seed);
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//1st Jump and Branch MUX Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, and then 0.
+
+module first_jump_or_branch_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_PC_plus_4, In2_BTA;
+reg Ctrl_Branch_Gate;
+wire [31:0] out;
+
+first_jump_or_branch_mux_2_to_1 dut(	
+
+	.In1_PC_plus_4(In1_PC_plus_4), 
+	.In2_BTA(In2_BTA), 
+	.Ctrl_Branch_Gate(Ctrl_Branch_Gate),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_Branch_Gate = 0;
+		#5
+		Ctrl_Branch_Gate = 0;
+		In1_PC_plus_4 = $random(seed);
+		In2_BTA = $random(seed);
+		#5
+		In1_PC_plus_4 = $random(seed);
+		In2_BTA = $random(seed);
+		Ctrl_Branch_Gate = 1;
+		#5
+		In1_PC_plus_4 = $random(seed);
+		In2_BTA = $random(seed);
+		Ctrl_Branch_Gate = 0;
+		#5
+		In1_PC_plus_4 = $random(seed);
+		In2_BTA = $random(seed);
+		Ctrl_Branch_Gate = 1;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//2nd Jump and Branch MUX Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, and then 0.
+
+module second_jump_or_branch_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_first_mux, In2_jump_addr_calc;
+reg Ctrl_Jump;
+wire [31:0] out;
+
+second_jump_or_branch_mux_2_to_1 dut(	
+
+	.In1_first_mux(In1_first_mux), 
+	.In2_jump_addr_calc(In2_jump_addr_calc), 
+	.Ctrl_Jump(Ctrl_Jump),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_Jump = 0;
+		#5
+		Ctrl_Jump = 0;
+		In1_first_mux = $random(seed);
+		In2_jump_addr_calc = $random(seed);
+		#5
+		In1_first_mux = $random(seed);
+		In2_jump_addr_calc = $random(seed);
+		Ctrl_Jump = 1;
+		#5
+		In1_first_mux = $random(seed);
+		In2_jump_addr_calc = $random(seed);
+		Ctrl_Jump = 0;
+		#5
+		In1_first_mux = $random(seed);
+		In2_jump_addr_calc = $random(seed);
+		Ctrl_Jump = 1;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//3rd Jump and Branch MUX Test Bench
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, and then 0.
+
+module third_jump_or_branch_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_second_mux, In2_reg_value_ra;
+reg JRCtrl;
+wire [31:0] out;
+
+third_jump_or_branch_mux_2_to_1 dut(	
+
+	.In1_second_mux(In1_second_mux), 
+	.In2_reg_value_ra(In2_reg_value_ra), 
+	.JRCtrl(JRCtrl),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		JRCtrl = 0;
+		#5
+		JRCtrl = 0;
+		In1_second_mux = $random(seed);
+		In2_reg_value_ra = $random(seed);
+		#5
+		In1_second_mux = $random(seed);
+		In2_reg_value_ra = $random(seed);
+		JRCtrl = 1;
+		#5
+		In1_second_mux = $random(seed);
+		In2_reg_value_ra = $random(seed);
+		JRCtrl = 0;
+		#5
+		In1_second_mux = $random(seed);
+		In2_reg_value_ra = $random(seed);
+		JRCtrl = 1;
+		#5
+		$finish;
+	end
+
+endmodule
+
+//--------------------------------------------------------------
+//Hazard Detection MUX in ID Stage
+//Changes input registers randomly every 5 time units.
+//Changes FwdA_control to 0, 1, and then 0.
+
+module hazard_stall_mux_2_to_1_tb();
+
+parameter tck = 10; ///< clock tick
+
+//input and output regs
+reg [31:0] In1_zero, In2_control_unit;
+reg Ctrl_Mux_Select_Stall;
+wire [31:0] out;
+
+hazard_stall_mux_2_to_1 dut(	
+
+	.In1_zero(In1_zero), 
+	.In2_control_unit(In2_control_unit), 
+	.Ctrl_Mux_Select_Stall(Ctrl_Mux_Select_Stall),
+	.out(out)
+			);
+
+integer seed = 3 ;
+
+initial begin
+		//$dumpfile("mux_tb.vcd");
+		$dumpvars(-1, dut);
+		$monitor("%b", out);
+	end
+
+initial begin
+		Ctrl_Mux_Select_Stall = 0;
+		#5
+		Ctrl_Mux_Select_Stall = 0;
+		In1_zero = $random(seed);
+		In2_control_unit = $random(seed);
+		#5
+		In1_zero = $random(seed);
+		In2_control_unit = $random(seed);
+		Ctrl_Mux_Select_Stall = 1;
+		#5
+		In1_zero = $random(seed);
+		In2_control_unit = $random(seed);
+		Ctrl_Mux_Select_Stall = 0;
+		#5
+		In1_zero = $random(seed);
+		In2_control_unit = $random(seed);
+		Ctrl_Mux_Select_Stall = 1;
 		#5
 		$finish;
 	end


### PR DESCRIPTION
 - Created test benches for each multiplexor
 - Added semicolons to end of module declaration in Multiplexer.v in order to allow for compilation
 - Fixed register size to match state conditions
 - Each test bench tests each of the cases for each Multiplexor at #(5) time delay intervals

All multiplexors output correct registers according to the different cases. It was a bit tedious creating test benches for each one, but hopefully this helps with confirming that the multiplexors work and hopefully will help with debugging later on. 
 
<img width="1277" alt="screen shot 2018-04-22 at 6 23 04 pm" src="https://user-images.githubusercontent.com/19338556/39101159-72a444f0-465b-11e8-816c-9a763bffcd0f.png">
